### PR TITLE
Add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "name": "args-typed",
   "version": "0.0.1",
   "scripts": {
-    "build": "rimraf dist && tsc && cpy README.md dist && package-json-minifier"
+    "build": "rimraf dist && tsc && cpy README.md dist && package-json-minifier",
+    "test": "node --test --import tsx tests/*.ts"
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { command, run } from '../src/index';
+
+test('command parses options and positionals', () => {
+  const cmd = command({ description: 'Test command' })
+    .positional('file', 'file to process')
+    .option('f', 'force', 'force flag', 'boolean')
+    .option(undefined, 'num', 'a number', 'scalar', (v) => parseInt(v, 10))
+    .build(([file], { force, num }) => ({ file, force, num }));
+
+  const result = run(cmd, ['-f', '--num', '5', 'my.txt'], {}, 'cmd');
+  assert.deepStrictEqual(result, { file: 'my.txt', force: true, num: 5 });
+});

--- a/tests/sample.test.ts
+++ b/tests/sample.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import util from 'node:util';
+import { command, commandGroup, run } from '../src/index';
+
+interface OuterContext { ft: number; }
+interface AppContext { cwd?: string; }
+
+// Build copy command similar to sample, without exiting on --help
+function makeCopy() {
+  return command({ description: 'Copy a file' })
+    .positional('source', 'The source file')
+    .positional('destination', 'The destination file')
+    .option('h', 'help', 'Show help', 'boolean')
+    .option('f', 'force', 'Force overwrite', 'boolean')
+    .option('r', 'recursive', 'Copy recursively', 'boolean')
+    .build<AppContext, number>(([source, destination], { help, force, recursive }, { fullName, printDescription, context }) => {
+      if (help) {
+        // In tests just print description instead of exiting
+        printDescription(fullName);
+        return 0;
+      }
+      console.log(`Copying ${source} to ${destination}${force || recursive ? `,${force ? ' force' : ''}${recursive ? ' recursive' : ''}` : ''}`);
+      // return fixed number so we can assert on it
+      return 42;
+    });
+}
+
+test('sample usage parses arguments and maps context', () => {
+  const logs: string[] = [];
+  const orig = console.log;
+  console.log = (...args: any[]) => { logs.push(util.format(...args)); };
+  let received: OuterContext & AppContext | undefined;
+
+  const copy = makeCopy();
+  const app = commandGroup<AppContext>({ description: 'Sample app' })
+    .command('copy', copy)
+    .command('cp', copy)
+    .option('C', 'cwd', 'change directory', 'scalar')
+    .build<OuterContext>((args, { cwd }, { context }) => {
+      received = { ...context, cwd };
+      console.log('args:', args);
+      return { ...context, cwd };
+    });
+
+  const result = run(app, ['-C', 'dir', 'copy', 'a', 'b'], { ft: 7 }, 'app');
+
+  console.log = orig;
+
+  assert.equal(result, 42);
+  assert.deepStrictEqual(received, { ft: 7, cwd: 'dir' });
+  assert.deepStrictEqual(logs, ["args: [ 'a', 'b' ]", 'Copying a to b']);
+});


### PR DESCRIPTION
## Summary
- add a basic test for command parsing
- add a test demonstrating sample usage
- add npm test script running Node's test runner via tsx

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879e7d4811c83288e6c9180ccc5f4be