### PR TITLE
Use parseOptions in argument parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,6 +522,8 @@ class Command<
       name: string,
       fullName: string
     ): T {
+      const { allowOptionAfterPositional, allowDuplicateOptions } =
+        self.parseOptions;
       const positional: any[] = [];
       const options: any = {};
       const extra: any[] = [];
@@ -568,7 +570,7 @@ class Command<
                 `[args-typed] boolean option --${longFlag} does not take a value`
               );
             }
-            if (options[longFlag]) {
+            if (!allowDuplicateOptions && options[longFlag]) {
               throw new ParseError(
                 `[args-typed] option --${longFlag}${
                   option.short ? ` (-${option.short})` : ""
@@ -590,7 +592,7 @@ class Command<
                 option.type.parse(args[i]),
               ];
             } else {
-              if (typeof options[longFlag] !== "undefined") {
+              if (!allowDuplicateOptions && typeof options[longFlag] !== "undefined") {
                 throw new ParseError(
                   `[args-typed] option --${longFlag}${
                     option.short ? ` (-${option.short})` : ""
@@ -613,7 +615,7 @@ class Command<
             const longFlag = self.shortOptions[shortFlag]!;
             const option = self.optionsData[longFlag]!;
             if (option.type.type === "boolean") {
-              if (options[longFlag]) {
+              if (!allowDuplicateOptions && options[longFlag]) {
                 throw new ParseError(
                   `[args-typed] option --${longFlag} (-${shortFlag}) given multiple times`
                 );
@@ -629,7 +631,7 @@ class Command<
                     option.type.parse(args[i]),
                   ];
                 } else {
-                  if (typeof options[longFlag] !== "undefined") {
+                  if (!allowDuplicateOptions && typeof options[longFlag] !== "undefined") {
                     throw new ParseError(
                       `[args-typed] option --${longFlag}${
                         option.short ? ` (-${option.short})` : ""
@@ -651,7 +653,7 @@ class Command<
                     option.type.parse(args[i]),
                   ];
                 } else {
-                  if (typeof options[longFlag] !== "undefined") {
+                  if (!allowDuplicateOptions && typeof options[longFlag] !== "undefined") {
                     throw new ParseError(
                       `[args-typed] option --${longFlag}${
                         option.short ? ` (-${option.short})` : ""
@@ -665,7 +667,9 @@ class Command<
             }
           }
         } else {
-          parsingFlag = false;
+          if (!allowOptionAfterPositional) {
+            parsingFlag = false;
+          }
           if (posIndex < self.positionalData.length) {
             positional.push(self.positionalData[posIndex].parse(current));
             posIndex++;
@@ -716,7 +720,6 @@ class CommandGroup<
     private readonly optionsData: Partial<Record<string, OptionData>>,
     private readonly shortOptions: ShortOptions,
     private readonly parseOptions: {
-      allowOptionAfterPositional?: boolean;
       allowDuplicateOptions?: boolean;
     }
   ) {}
@@ -726,7 +729,6 @@ class CommandGroup<
     ...options
   }: {
     description: string;
-    allowOptionAfterPositional?: boolean;
     allowDuplicateOptions?: boolean;
   }): CommandGroup<{}, {}, {}, InnerContext, T> {
     return new CommandGroup(description, {}, {}, {}, options);
@@ -1042,6 +1044,7 @@ class CommandGroup<
       name: string,
       fullName: string
     ): Result {
+      const { allowDuplicateOptions } = self.parseOptions;
       const options: any = {};
       let command: string | undefined;
       let i = 0;
@@ -1082,7 +1085,7 @@ class CommandGroup<
                 `[args-typed] boolean option --${longFlag} does not take a value`
               );
             }
-            if (options[longFlag]) {
+            if (!allowDuplicateOptions && options[longFlag]) {
               throw new ParseError(
                 `[args-typed] option --${longFlag}${
                   option.short ? ` (-${option.short})` : ""
@@ -1104,7 +1107,7 @@ class CommandGroup<
                 option.type.parse(args[i]),
               ];
             } else {
-              if (typeof options[longFlag] !== "undefined") {
+              if (!allowDuplicateOptions && typeof options[longFlag] !== "undefined") {
                 throw new ParseError(
                   `[args-typed] option --${longFlag}${
                     option.short ? ` (-${option.short})` : ""
@@ -1119,15 +1122,15 @@ class CommandGroup<
           let sfIndex = 0;
           while (sfIndex < shortFlags.length) {
             const shortFlag = shortFlags[sfIndex];
-            if (!(shortFlag in self.shortOptions)) {
-              throw new ParseError(
-                `[args-typed] unknown short option -${shortFlag} given`
-              );
-            }
+          if (!(shortFlag in self.shortOptions)) {
+            throw new ParseError(
+              `[args-typed] unknown short option -${shortFlag} given`
+            );
+          }
             const longFlag = self.shortOptions[shortFlag]!;
             const option = self.optionsData[longFlag]!;
             if (option.type.type === "boolean") {
-              if (options[longFlag]) {
+              if (!allowDuplicateOptions && options[longFlag]) {
                 throw new ParseError(
                   `[args-typed] option --${longFlag} (-${shortFlag}) given multiple times`
                 );
@@ -1143,7 +1146,7 @@ class CommandGroup<
                     option.type.parse(args[i]),
                   ];
                 } else {
-                  if (typeof options[longFlag] !== "undefined") {
+                  if (!allowDuplicateOptions && typeof options[longFlag] !== "undefined") {
                     throw new ParseError(
                       `[args-typed] option --${longFlag}${
                         option.short ? ` (-${option.short})` : ""
@@ -1165,7 +1168,7 @@ class CommandGroup<
                     option.type.parse(args[i]),
                   ];
                 } else {
-                  if (typeof options[longFlag] !== "undefined") {
+                  if (!allowDuplicateOptions && typeof options[longFlag] !== "undefined") {
                     throw new ParseError(
                       `[args-typed] option --${longFlag}${
                         option.short ? ` (-${option.short})` : ""


### PR DESCRIPTION
## Summary
- use `allowOptionAfterPositional` and `allowDuplicateOptions` during parsing
- permit optional parsing of options after positionals and duplicates

## Testing
- `npm run build`
- `cd sample && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6879f3a52e1883289433900bda0f0e4f